### PR TITLE
fix(package): add Editor directory to package include files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "*.asmdef",
         "*.xml",
         "Documentation",
+        "Editor",
         "Runtime"
     ]
 }


### PR DESCRIPTION
The Editor directory should also be inlcuded in the package for a
successful build.