### PR TITLE
fix(structure): add missing .meta file

### DIFF
--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0a854e76213d9a489c36475991b8942
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The CHANGELOG.md file is automatically created by the CI+CD system
and therefore does not exist for Unity to create the .meta file
for it until the release has occurred.

This fix manually adds in the missing .meta file.