### PR TITLE
fix(Editor): add asmdef file for editor scripts

### DIFF
--- a/Editor/Tilia.Input.UnityInputManager.Editor.asmdef
+++ b/Editor/Tilia.Input.UnityInputManager.Editor.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Tilia.Input.UnityInputManager.Editor",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Editor/Tilia.Input.UnityInputManager.Editor.asmdef.meta
+++ b/Editor/Tilia.Input.UnityInputManager.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9d3e9d4688acf8144b8df18e99525642
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Editor scripts were not being executed when the package was used
due to no asmdef being present to load in the scripts. This has
now been added.