### PR TITLE
fix(AxisCreator): increase sensitivity for axis 4 and 5

### DIFF
--- a/Editor/UnityInputManagerAxisCreator.cs
+++ b/Editor/UnityInputManagerAxisCreator.cs
@@ -45,8 +45,8 @@
         private static Vector2 scrollPosition;
 
         private static readonly InputAxis axis3 = new InputAxis() { name = "Tilia.Input.UnityInputManager_Axis3", dead = 0.001f, sensitivity = 1f, snap = true, type = AxisType.JoystickAxis, axis = 3, joyNum = 0 };
-        private static readonly InputAxis axis4 = new InputAxis() { name = "Tilia.Input.UnityInputManager_Axis4", dead = 0.001f, sensitivity = 1f, snap = true, type = AxisType.JoystickAxis, axis = 4, joyNum = 0 };
-        private static readonly InputAxis axis5 = new InputAxis() { name = "Tilia.Input.UnityInputManager_Axis5", dead = 0.001f, sensitivity = 1f, snap = true, invert = true, type = AxisType.JoystickAxis, axis = 5, joyNum = 0 };
+        private static readonly InputAxis axis4 = new InputAxis() { name = "Tilia.Input.UnityInputManager_Axis4", dead = 0.001f, sensitivity = 3f, snap = true, type = AxisType.JoystickAxis, axis = 4, joyNum = 0 };
+        private static readonly InputAxis axis5 = new InputAxis() { name = "Tilia.Input.UnityInputManager_Axis5", dead = 0.001f, sensitivity = 3f, snap = true, invert = true, type = AxisType.JoystickAxis, axis = 5, joyNum = 0 };
         private static readonly InputAxis axis6 = new InputAxis() { name = "Tilia.Input.UnityInputManager_Axis6", dead = 0.001f, sensitivity = 1f, snap = true, type = AxisType.JoystickAxis, axis = 6, joyNum = 0 };
         private static readonly InputAxis axis7 = new InputAxis() { name = "Tilia.Input.UnityInputManager_Axis7", dead = 0.001f, sensitivity = 1f, snap = true, type = AxisType.JoystickAxis, axis = 7, joyNum = 0 };
         private static readonly InputAxis axis8 = new InputAxis() { name = "Tilia.Input.UnityInputManager_Axis8", dead = 0.001f, sensitivity = 1f, snap = true, type = AxisType.JoystickAxis, axis = 8, joyNum = 0 };


### PR DESCRIPTION
Axis 4 and 5 generally relates to the right controller
touchpad/thumbstick and if the sensitivity is too low then diagonal
movement vectors seem multiplied. The Horizontal and Vertical axes have
a sensitivity of `3` so this is now matching that setting.