### PR TITLE
fix(AxisCreator): prevent null exception if no axis found - fixes #74

### DIFF
--- a/Editor/UnityInputManagerAxisCreator.cs
+++ b/Editor/UnityInputManagerAxisCreator.cs
@@ -182,8 +182,10 @@
             while (axesProperty.Next(false))
             {
                 SerializedProperty axis = axesProperty.Copy();
-                axis.Next(true);
-                if (axis.stringValue == axisName) return true;
+                if (axis.Next(true))
+                {
+                    if (axis.stringValue == axisName) return true;
+                }
             }
             return false;
         }


### PR DESCRIPTION
There was an issue when no axis was found it would throw a null
exception as the `Next` call would try and iterate through to a
null element. This is resolved by just using the resulting bool
from the `Next` call to ensure whether it can proceed wit the
additional check.