### PR TITLE
feat(Malimbe): remove malimbe dependency

### DIFF
--- a/Editor/Tilia.Input.UnityInputManager.Editor.asmdef
+++ b/Editor/Tilia.Input.UnityInputManager.Editor.asmdef
@@ -10,9 +10,7 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "Malimbe.FodyRunner.UnityIntegration.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": []
 }

--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<Weavers>
-  <Malimbe.FodyRunner>
-    <AssemblyNameRegex>^Tilia.Input.UnityInputManager</AssemblyNameRegex>
-  </Malimbe.FodyRunner>
-</Weavers>

--- a/FodyWeavers.xml.meta
+++ b/FodyWeavers.xml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 4e707bfdbdf195c4fac2d1167c7ed281
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/UnityInputManagerAxis1DAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerAxis1DAction.cs
@@ -1,7 +1,5 @@
 ﻿namespace Tilia.Input.UnityInputManager
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Zinnia.Action;
     using Zinnia.Process;
@@ -11,18 +9,40 @@
     /// </summary>
     public class UnityInputManagerAxis1DAction : FloatAction, IProcessable
     {
+        [Tooltip("The named axis to listen for state changes on.")]
+        [SerializeField]
+        private string axisName;
         /// <summary>
         /// The named axis to listen for state changes on.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public string AxisName { get; set; }
+        public string AxisName
+        {
+            get
+            {
+                return axisName;
+            }
+            set
+            {
+                axisName = value;
+            }
+        }
+        [Tooltip("Multiplies the axis value.")]
+        [SerializeField]
+        private float multiplier = 1f;
         /// <summary>
         /// Multiplies the axis value.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public float Multiplier { get; set; } = 1f;
+        public float Multiplier
+        {
+            get
+            {
+                return multiplier;
+            }
+            set
+            {
+                multiplier = value;
+            }
+        }
 
         /// <inheritdoc />
         public void Process()

--- a/Runtime/SharedResources/Scripts/UnityInputManagerAxis2DAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerAxis2DAction.cs
@@ -1,7 +1,5 @@
 ﻿namespace Tilia.Input.UnityInputManager
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Zinnia.Action;
     using Zinnia.Process;
@@ -11,30 +9,74 @@
     /// </summary>
     public class UnityInputManagerAxis2DAction : Vector2Action, IProcessable
     {
+        [Tooltip("The named x axis to listen for state changes on.")]
+        [SerializeField]
+        private string xAxisName;
         /// <summary>
         /// The named x axis to listen for state changes on.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public string XAxisName { get; set; }
+        public string XAxisName
+        {
+            get
+            {
+                return xAxisName;
+            }
+            set
+            {
+                xAxisName = value;
+            }
+        }
+        [Tooltip("The named y axis to listen for state changes on.")]
+        [SerializeField]
+        private string yAxisName;
         /// <summary>
         /// The named y axis to listen for state changes on.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public string YAxisName { get; set; }
+        public string YAxisName
+        {
+            get
+            {
+                return yAxisName;
+            }
+            set
+            {
+                yAxisName = value;
+            }
+        }
+        [Tooltip("Multiplies the x axis value.")]
+        [SerializeField]
+        private float xMultiplier = 1f;
         /// <summary>
         /// Multiplies the x axis value.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public float XMultiplier { get; set; } = 1f;
+        public float XMultiplier
+        {
+            get
+            {
+                return xMultiplier;
+            }
+            set
+            {
+                xMultiplier = value;
+            }
+        }
+        [Tooltip("Multiplies the y axis value.")]
+        [SerializeField]
+        private float yMultiplier = 1f;
         /// <summary>
         /// Multiplies the y axis value.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public float YMultiplier { get; set; } = 1f;
+        public float YMultiplier
+        {
+            get
+            {
+                return yMultiplier;
+            }
+            set
+            {
+                yMultiplier = value;
+            }
+        }
 
         /// <inheritdoc />
         public void Process()

--- a/Runtime/SharedResources/Scripts/UnityInputManagerButtonAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerButtonAction.cs
@@ -1,7 +1,5 @@
 ﻿namespace Tilia.Input.UnityInputManager
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Zinnia.Action;
     using Zinnia.Process;
@@ -11,12 +9,23 @@
     /// </summary>
     public class UnityInputManagerButtonAction : BooleanAction, IProcessable
     {
+        [Tooltip("The KeyCode to listen for state changes on.")]
+        [SerializeField]
+        private KeyCode keyCode;
         /// <summary>
         /// The <see cref="UnityEngine.KeyCode"/> to listen for state changes on.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public KeyCode KeyCode { get; set; }
+        public KeyCode KeyCode
+        {
+            get
+            {
+                return keyCode;
+            }
+            set
+            {
+                keyCode = value;
+            }
+        }
 
         /// <inheritdoc />
         public void Process()

--- a/Runtime/Tilia.Input.UnityInputManager.Runtime.asmdef
+++ b/Runtime/Tilia.Input.UnityInputManager.Runtime.asmdef
@@ -8,10 +8,7 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "Malimbe.PropertySerializationAttribute.dll",
-        "Malimbe.XmlDocumentationAttribute.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": []
 }


### PR DESCRIPTION
BREAKING CHANGE: This removes the last remaining elements of
Malimbe and whilst it does not cause any breaking changes within
this package, it removes Malimbe as a dependency which other projects
that rely on this package may piggy back off this Malimbe dependency
so it will break any project like that.

All of the previous functionality from Malimbe has been replicated in
standard code without the need for it to be weaved by the Malimbe
helper tags.