### PR TITLE
feat(state): add ifdefs to determine whether input manager is enabled

### DIFF
--- a/Runtime/SharedResources/Scripts/UnityInputManagerAxis1DAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerAxis1DAction.cs
@@ -47,7 +47,11 @@
         /// <inheritdoc />
         public void Process()
         {
+#if ENABLE_LEGACY_INPUT_MANAGER
             Receive(Input.GetAxis(AxisName) * Multiplier);
+#else
+            Debug.LogWarning("The Legacy Unity Input Manager is disabled in the player settings.");
+#endif
         }
     }
 }

--- a/Runtime/SharedResources/Scripts/UnityInputManagerAxis2DAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerAxis2DAction.cs
@@ -81,7 +81,11 @@
         /// <inheritdoc />
         public void Process()
         {
+#if ENABLE_LEGACY_INPUT_MANAGER
             Receive(new Vector2(Input.GetAxis(XAxisName) * XMultiplier, Input.GetAxis(YAxisName) * YMultiplier));
+#else
+            Debug.LogWarning("The Legacy Unity Input Manager is disabled in the player settings.");
+#endif
         }
     }
 }

--- a/Runtime/SharedResources/Scripts/UnityInputManagerButtonAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerButtonAction.cs
@@ -30,7 +30,11 @@
         /// <inheritdoc />
         public void Process()
         {
+#if ENABLE_LEGACY_INPUT_MANAGER
             Receive(Input.GetKey(KeyCode));
+#else
+            Debug.LogWarning("The Legacy Unity Input Manager is disabled in the player settings.");
+#endif
         }
     }
 }


### PR DESCRIPTION
The relevant input manager code is now wrapped in ifdefs to only run if the Unity Input Manager is enabled and therefore will provide a warning if the code is run when it is not enabled.