### PR TITLE
fix(state): only apply ifdef on Unity 2019.2 or newer

### DIFF
--- a/Runtime/SharedResources/Scripts/UnityInputManagerAxis1DAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerAxis1DAction.cs
@@ -47,10 +47,14 @@
         /// <inheritdoc />
         public void Process()
         {
+#if UNITY_2019_2_OR_NEWER
 #if ENABLE_LEGACY_INPUT_MANAGER
             Receive(Input.GetAxis(AxisName) * Multiplier);
 #else
             Debug.LogWarning("The Legacy Unity Input Manager is disabled in the player settings.");
+#endif
+#else
+            Receive(Input.GetAxis(AxisName) * Multiplier);
 #endif
         }
     }

--- a/Runtime/SharedResources/Scripts/UnityInputManagerAxis2DAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerAxis2DAction.cs
@@ -81,10 +81,14 @@
         /// <inheritdoc />
         public void Process()
         {
+#if UNITY_2019_2_OR_NEWER
 #if ENABLE_LEGACY_INPUT_MANAGER
             Receive(new Vector2(Input.GetAxis(XAxisName) * XMultiplier, Input.GetAxis(YAxisName) * YMultiplier));
 #else
             Debug.LogWarning("The Legacy Unity Input Manager is disabled in the player settings.");
+#endif
+#else
+            Receive(new Vector2(Input.GetAxis(XAxisName) * XMultiplier, Input.GetAxis(YAxisName) * YMultiplier));
 #endif
         }
     }

--- a/Runtime/SharedResources/Scripts/UnityInputManagerButtonAction.cs
+++ b/Runtime/SharedResources/Scripts/UnityInputManagerButtonAction.cs
@@ -30,10 +30,14 @@
         /// <inheritdoc />
         public void Process()
         {
+#if UNITY_2019_2_OR_NEWER
 #if ENABLE_LEGACY_INPUT_MANAGER
             Receive(Input.GetKey(KeyCode));
 #else
             Debug.LogWarning("The Legacy Unity Input Manager is disabled in the player settings.");
+#endif
+#else
+            Receive(Input.GetKey(KeyCode));
 #endif
         }
     }


### PR DESCRIPTION
The ENABLE_LEGACY_INPUT_MANAGER was only added in Unity 2019.2 so any version before that won't understand the ifdef and therefore just output the debug warning.

This fix wraps that whole block in a check to see if Unity 2019.2 or newer is being used, if its not then it just does the default process and if the user is using the new Input System but has this package installed then they won't get any debug warnings, but as this is based on such an old version of unity then this is acceptable.